### PR TITLE
Fix typo in forms.html

### DIFF
--- a/forms.html
+++ b/forms.html
@@ -894,7 +894,7 @@ textarea {
     </table>
   </pre>
 </div></article><article id="form-element-choice" class="section"><div class="docs"><a href="#form-element-choice" class="permalink"><svg viewBox="0 0 512 512" height="32" width="32" class="icon"><path d="M156.2,199.7c7.5-7.5,15.9-13.8,24.8-18.7c49.6-27.3,113.1-12.8,145,35.5l-38.5,38.5c-11.1-25.2-38.5-39.6-65.8-33.5c-10.3,2.3-20.1,7.4-28,15.4l-73.9,73.9c-22.4,22.4-22.4,58.9,0,81.4c22.4,22.4,58.9,22.4,81.4,0l22.8-22.8c20.7,8.2,42.9,11.5,64.9,9.9l-50.3,50.3c-43.1,43.1-113,43.1-156.1,0c-43.1-43.1-43.1-113-0-156.1L156.2,199.7z M273.6,82.3l-50.3,50.3c21.9-1.6,44.2,1.6,64.9,9.9l22.8-22.8c22.4-22.4,58.9-22.4,81.4,0c22.4,22.4,22.4,58.9,0,81.4l-73.9,73.9c-22.5,22.5-59.1,22.3-81.4,0c-5.2-5.2-9.7-11.7-12.5-18l-38.5,38.5c4,6.1,8.3,11.5,13.7,16.9c13.9,13.9,31.7,24.3,52.1,29.3c26.5,6.4,54.8,2.8,79.2-10.6c8.9-4.9,17.3-11.1,24.8-18.7l73.9-73.9c43.1-43.1,43.1-113,0-156.1C386.6,39.2,316.7,39.2,273.6,82.3z"></path></svg></a><h1 id="form-element-choice">Form element choice</h1>
-<p>  The <code>.lib-form-element-choise()</code> mixin is used to customize checkboxes and radio buttons.</p>
+<p>  The <code>.lib-form-element-choice()</code> mixin is used to customize checkboxes and radio buttons.</p>
 <textarea class="preview-code" spellcheck="false">    &lt;input type="checkbox" name="checkbox-example" /&gt;&lt;label for="checkbox-example"&gt;Label for checkbox&lt;/label&gt;&lt;br /&gt;
     &lt;input type="radio" name="radio-example"  /&gt;&lt;label for="radio-example"&gt;Label for radio button&lt;/label&gt;</textarea>
 </div><div class="code"><pre><code>input[type="checkbox"] {


### PR DESCRIPTION
What title says. There is a typo in forms.html in regards to lib-form-element-choice LESS mixin.